### PR TITLE
Use sdk.getpebble.com URLs for the SDK download

### DIFF
--- a/pebble-sdk-legacy.rb
+++ b/pebble-sdk-legacy.rb
@@ -7,7 +7,7 @@ class PebbleSdkLegacy < Formula
   PEBBLE_SDK_SHA256='9eb9dee08c88f192a6403717d8b32d67f49e598efb1b6e530056f008c5a2f465'
 
   homepage 'https://developer.getpebble.com'
-  url "http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk2/PebbleSDK-#{PEBBLE_SDK_VERSION}.tar.gz"
+  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}/?source=homebrew-legacy"
   sha256 "#{PEBBLE_SDK_SHA256}"
   version "#{PEBBLE_SDK_VERSION}"
 

--- a/pebble-sdk-legacy.rb
+++ b/pebble-sdk-legacy.rb
@@ -7,7 +7,7 @@ class PebbleSdkLegacy < Formula
   PEBBLE_SDK_SHA256='9eb9dee08c88f192a6403717d8b32d67f49e598efb1b6e530056f008c5a2f465'
 
   homepage 'https://developer.getpebble.com'
-  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}/?source=homebrew-legacy"
+  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}?source=homebrew-legacy"
   sha256 "#{PEBBLE_SDK_SHA256}"
   version "#{PEBBLE_SDK_VERSION}"
 

--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -14,7 +14,7 @@ class PebbleSdk < Formula
   PEBBLE_SDK_SHA256='2441a712af16d59f1f3d3375094d03a83da75ca32bf7a7d28d2e423c6d457092'
 
   homepage 'https://developer.getpebble.com'
-  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}/?source=homebrew"
+  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}?source=homebrew"
   sha256 "#{PEBBLE_SDK_SHA256}"
   version PebbleSdk::Version.new("#{PEBBLE_SDK_VERSION}")
 

--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -14,7 +14,7 @@ class PebbleSdk < Formula
   PEBBLE_SDK_SHA256='2441a712af16d59f1f3d3375094d03a83da75ca32bf7a7d28d2e423c6d457092'
 
   homepage 'https://developer.getpebble.com'
-  url "http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk2/PebbleSDK-#{PEBBLE_SDK_VERSION}.tar.gz"
+  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}/?source=homebrew"
   sha256 "#{PEBBLE_SDK_SHA256}"
   version PebbleSdk::Version.new("#{PEBBLE_SDK_VERSION}")
 

--- a/pebble-sdk.rb.template
+++ b/pebble-sdk.rb.template
@@ -14,7 +14,7 @@ class PebbleSdk < Formula
   INSERT_HASH
 
   homepage 'https://developer.getpebble.com'
-  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}/?source=homebrew"
+  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}?source=homebrew"
   sha256 "#{PEBBLE_SDK_SHA256}"
   version PebbleSdk::Version.new("#{PEBBLE_SDK_VERSION}")
 

--- a/pebble-sdk.rb.template
+++ b/pebble-sdk.rb.template
@@ -14,7 +14,7 @@ class PebbleSdk < Formula
   INSERT_HASH
 
   homepage 'https://developer.getpebble.com'
-  url "http://assets.getpebble.com.s3-website-us-east-1.amazonaws.com/sdk2/PebbleSDK-#{PEBBLE_SDK_VERSION}.tar.gz"
+  url "https://sdk.getpebble.com/download/#{PEBBLE_SDK_VERSION}/?source=homebrew"
   sha256 "#{PEBBLE_SDK_SHA256}"
   version PebbleSdk::Version.new("#{PEBBLE_SDK_VERSION}")
 


### PR DESCRIPTION
Let me know if I messed up or need to make the change in more places.