### PR TITLE
A whole new world!

### DIFF
--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -6,7 +6,7 @@ class PebbleQemu < Formula
   version "2.1.1-pebble1"
 
   bottle do
-    root_url "http://pebble-homebrew.s3.amazonaws.com"
+    root_url "http://pebble-sdk-homebrew.s3.amazonaws.com"
     cellar :any
     sha256 "ed312703b691e67c4cafd62f0447ae9f2eef3662cd8baf8597f02cd14293b7ed" => :el_capitan
   end

--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -9,7 +9,9 @@ class PebbleQemu < Formula
   bottle do
     root_url "http://pebble-sdk-homebrew.s3.amazonaws.com"
     cellar :any
+    revision 1
     sha256 "b55b5940b9439c4ee0cb1484e7209d28d527d2d1e3dcb1e82a2ee5212d01a702" => :el_capitan
+    sha256 "258bff04da3487a0dbdc0f0f22b1ad0e99261ae6d76150e7a7d114268a64b0e7" => :yosemite
   end
 
   depends_on "pkg-config" => :build

--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -1,0 +1,36 @@
+class PebbleQemu < Formula
+  homepage "https://github.com/pebble/qemu"
+  url "https://github.com/pebble/qemu/archive/v2.1.1-pebble1.zip"
+  sha256 "a7b1047492ab969725d90efa42a95ac22e69b271c7847a1a19606b3ea226f025"
+  version "2.1.1-pebble1"
+
+  bottle do
+    root_url "http://pebble-homebrew.s3.amazonaws.com"
+    cellar :any
+    sha256 "ed312703b691e67c4cafd62f0447ae9f2eef3662cd8baf8597f02cd14293b7ed" => :el_capitan
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "dtc" => :build
+
+  depends_on "glib"
+  depends_on "pixman"
+  depends_on "libpng"
+  depends_on "libjpeg"
+
+  def install
+    system "./configure", "--disable-werror",
+                          "--enable-debug",
+                          '--target-list=arm-softmmu',
+                          "--extra-cflags=-DSTM32_UART_NO_BAUD_DELAY",
+                          "--prefix=#{prefix}",
+                          "--disable-mouse"
+
+    system "make"
+    bin.install ["arm-softmmu/qemu-system-arm"]
+    mv bin/"qemu-system-arm", bin/"qemu-pebble"
+  end
+end

--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -9,7 +9,7 @@ class PebbleQemu < Formula
   bottle do
     root_url "http://pebble-sdk-homebrew.s3.amazonaws.com"
     cellar :any
-    sha256 "ed312703b691e67c4cafd62f0447ae9f2eef3662cd8baf8597f02cd14293b7ed" => :el_capitan
+    sha256 "b55b5940b9439c4ee0cb1484e7209d28d527d2d1e3dcb1e82a2ee5212d01a702" => :el_capitan
   end
 
   depends_on "pkg-config" => :build

--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -2,6 +2,7 @@ class PebbleQemu < Formula
   homepage "https://github.com/pebble/qemu"
   url "https://github.com/pebble/qemu/archive/v2.1.1-pebble1.zip"
   sha256 "a7b1047492ab969725d90efa42a95ac22e69b271c7847a1a19606b3ea226f025"
+  head "https://github.com/pebble/qemu.git"
   version "2.1.1-pebble1"
 
   bottle do
@@ -30,7 +31,9 @@ class PebbleQemu < Formula
                           "--disable-mouse"
 
     system "make"
+    # We only need the one binary.
     bin.install ["arm-softmmu/qemu-system-arm"]
-    mv bin/"qemu-system-arm", bin/"qemu-pebble"
+    # Rename it to avoid conflicting with more standard QEMUs.
+    mv bin/"qemu-system-arm", bin/"pebble-qemu"
   end
 end

--- a/pebble-qemu.rb
+++ b/pebble-qemu.rb
@@ -4,6 +4,7 @@ class PebbleQemu < Formula
   sha256 "a7b1047492ab969725d90efa42a95ac22e69b271c7847a1a19606b3ea226f025"
   head "https://github.com/pebble/qemu.git"
   version "2.1.1-pebble1"
+  revision 1
 
   bottle do
     root_url "http://pebble-sdk-homebrew.s3.amazonaws.com"
@@ -34,6 +35,6 @@ class PebbleQemu < Formula
     # We only need the one binary.
     bin.install ["arm-softmmu/qemu-system-arm"]
     # Rename it to avoid conflicting with more standard QEMUs.
-    mv bin/"qemu-system-arm", bin/"pebble-qemu"
+    mv bin/"qemu-system-arm", bin/"qemu-pebble"
   end
 end

--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -377,6 +377,7 @@ class PebbleSdk < Formula
         :PYTHONPATH => ENV["PYTHONPATH"],
         :PHONESIM_PATH => libexec/"pypkjs/phonesim.py",
         :PEBBLE_TOOLCHAIN_PATH => HOMEBREW_PREFIX/"Cellar/pebble-toolchain/2.0/arm-cs-tools/bin",
+        :PEBBLE_IS_HOMEBREW => "1",
       )
     end
   end

--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -152,8 +152,9 @@ class PebbleSdk < Formula
   end
 
   devel do
-    version PebbleSdk::Version.new("4.0-rc0")
-    url 'https://github.com/pebble/pebble-tool.git', :tag => 'v4.0-rc0'
+    version PebbleSdk::Version.new("4.0-rc1")
+    url 'https://github.com/pebble/pebble-tool/archive/v4.0-rc1.zip'
+    sha256 '3f27edc2c0674966b9bb5e0de0ccb5895d0e0f539412053987e057a4bbc8da61'
 
     depends_on 'freetype' => :recommended
     depends_on 'boost-python'

--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -173,7 +173,12 @@ class PebbleSdk < Formula
     system "python", *Language::Python.setup_install_args(libexec)
 
     bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"], :PHONESIM_PATH => libexec/"pypkjs/phonesim.py")
+    bin.env_script_all_files(
+      libexec/"bin",
+      :PYTHONPATH => ENV["PYTHONPATH"],
+      :PHONESIM_PATH => libexec/"pypkjs/phonesim.py",
+      :PEBBLE_TOOLCHAIN_PATH => HOMEBREW_PREFIX/"Cellar/pebble-toolchain/2.0/arm-cs-tools/bin",
+    )
   end
 
   test do

--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -154,7 +154,7 @@ class PebbleSdk < Formula
   devel do
     version PebbleSdk::Version.new("4.0-rc1")
     url 'https://github.com/pebble/pebble-tool/archive/v4.0-rc1.zip'
-    sha256 '3f27edc2c0674966b9bb5e0de0ccb5895d0e0f539412053987e057a4bbc8da61'
+    sha256 '0e234c31f7f8e15ea21d1b94773414e7b29dca59123111fa3c9a9bf80c83cdaf'
 
     depends_on 'freetype' => :recommended
     depends_on 'boost-python'

--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -8,177 +8,377 @@ class PebbleSdk < Formula
   end
 
   homepage 'https://developer.getpebble.com'
-  # url "https://sdk.getpebble.com/download/3.6?source=homebrew"
-  # sha256 "5e25620486a2f4ff600436ab4e9f71a4e23d4d4bc2d8fa73844d75c8344719f7"
-  # version PebbleSdk::Version.new("4.0")
-  head 'https://github.com/pebble/pebble-tool.git', :branch => "feature/multiple-sdks"
+  stable do
+    url "https://sdk.getpebble.com/download/3.7?source=homebrew"
+    sha256 "794f85f0e0f892ae938651ded91b1da544cb0835226f97b38a66233b2f93a2c7"
+    version PebbleSdk::Version.new("3.7")
 
-  depends_on 'freetype' => :recommended
-  depends_on 'boost-python'
+    depends_on 'freetype' => :recommended
 
-  depends_on 'pebble-toolchain'
-  depends_on 'pebble-qemu'
+    depends_on 'pebble-toolchain'
+    depends_on 'boost-python'
+    depends_on 'glib'
+    depends_on 'pixman'
 
-  depends_on :python if MacOS.version <= :snow_leopard
+    resource 'backports.ssl-match-hostname' do
+      url 'https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.4.0.2.tar.gz'
+      sha256 '07410e7fb09aab7bdaf5e618de66c3dac84e2e3d628352814dc4c37de321d6ae'
+    end
 
-  resource 'pypkjs' do
-    url 'https://github.com/pebble/pypkjs.git', :branch => "3.x-on-tintin"
+    resource 'colorama' do
+      url 'https://pypi.python.org/packages/source/c/colorama/colorama-0.3.3.tar.gz'
+      sha256 'eb21f2ba718fbf357afdfdf6f641ab393901c7ca8d9f37edd0bee4806ffa269c'
+    end
+
+    resource 'enum34' do
+      url 'https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.tar.gz'
+      sha256 'd3c19f26a6a34629c18c775f59dfc5dd595764c722b57a2da56ebfb69b94e447'
+    end
+
+    resource 'freetype-py' do
+      url 'https://pypi.python.org/packages/source/f/freetype-py/freetype-py-1.0.tar.gz'
+      sha256 '1fc67817d5fb9f1329a1a431850a46f01f250a1d6380e4bcecdb54266023e99a'
+    end
+
+    resource 'gevent' do
+      url 'https://pypi.python.org/packages/source/g/gevent/gevent-1.1b5.tar.gz'
+      sha256 '39e5848b4e8bd20846a43772e1ec8f3c4b8b0cff43611e0d73d809b5dc63f6fb'
+    end
+
+    resource 'gevent-websocket' do
+      url 'https://pypi.python.org/packages/source/g/gevent-websocket/gevent-websocket-0.9.3.tar.gz'
+      sha256 '6475220340f9f8895a0f51bd2b9df3511bc7765dc055f49e997584bdaee3381f'
+    end
+
+    resource 'greenlet' do
+      url 'https://pypi.python.org/packages/source/g/greenlet/greenlet-0.4.7.zip'
+      sha256 'f32c4fa4e06443e1bdb0d32b69e7617c25ff772c3ffc6d0aa63d192e9fd795fe'
+    end
+
+    resource 'httplib2' do
+      url 'https://pypi.python.org/packages/source/h/httplib2/httplib2-0.9.1.tar.gz'
+      sha256 'bc6339919a5235b9d1aaee011ca5464184098f0c47c9098001f91c97176583f5'
+    end
+
+    resource 'libpebble2' do
+      url 'https://pypi.python.org/packages/source/l/libpebble2/libpebble2-0.0.12.tar.gz'
+      sha256 '3ada5d0cb611569b8c92dae38cf224ffef4633be427359f0b478bc8b7d5afb97'
+    end
+
+    resource 'oauth2client' do
+      url 'https://pypi.python.org/packages/source/o/oauth2client/oauth2client-1.4.12.tar.gz'
+      sha256 '74aa6c3beb90a4a7b9b8d0bc3cd60db34d45c5ee6136187bb9eabe85b4990e5e'
+    end
+
+    resource 'peewee' do
+      url 'https://pypi.python.org/packages/source/p/peewee/peewee-2.4.7.tar.gz'
+      sha256 '8ad1c4fb202332a969da83a0af712bca96ed6e2a70ca1523ab3d2a2234ed47bd'
+    end
+
+    resource 'progressbar2' do
+      url 'https://pypi.python.org/packages/source/p/progressbar2/progressbar2-2.7.3.tar.gz'
+      sha256 '8366ffc752ebe3c8e50db2699b7b1dc3cb6ff3750065e965a2591ac50270b794'
+    end
+
+    resource 'pyasn1' do
+      url 'https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.1.8.tar.gz'
+      sha256 '5d33be7ca0ec5997d76d29ea4c33b65c00c0231407fff975199d7f40530b8347'
+    end
+
+    resource 'pyasn1-modules' do
+      url 'https://pypi.python.org/packages/source/p/pyasn1-modules/pyasn1-modules-0.0.6.tar.gz'
+      sha256 '1f41d3f3da43e9a769e23649724368aa0b88afcfd1fe6e9f210d31d13322fc15'
+    end
+
+    resource 'pygeoip' do
+      url 'https://pypi.python.org/packages/source/p/pygeoip/pygeoip-0.3.2.tar.gz'
+      sha256 'f22c4e00ddf1213e0fae36dc60b46ee7c25a6339941ec1a975539014c1f9a96d'
+    end
+
+    resource 'pypng' do
+      url 'https://pypi.python.org/packages/source/p/pypng/pypng-0.0.17.tar.gz'
+      sha256 '2dfa74ac28a4c41ae61e62d243410548c7c174bd990528d30270324f15211544'
+    end
+
+    resource 'pyqrcode' do
+      url 'https://pypi.python.org/packages/source/P/PyQRCode/PyQRCode-1.1.tar.gz'
+      sha256 'a22814bf88c8632ebe496e3300793c12471bb448d3186032445990c44ddcdd51'
+    end
+
+    resource 'pyserial' do
+      url 'https://pypi.python.org/packages/source/p/pyserial/pyserial-2.7.tar.gz'
+      sha256 '3542ec0838793e61d6224e27ff05e8ce4ba5a5c5cc4ec5c6a3e8d49247985477'
+    end
+
+    resource 'python-dateutil' do
+      url 'https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.4.1.post1.tar.gz'
+      sha256 'aa9bdbd60c395db90204609f1fb5aeb3797870f65c09f04f243476d22f8f4615'
+    end
+
+    resource 'requests' do
+      url 'https://pypi.python.org/packages/source/r/requests/requests-2.7.0.tar.gz'
+      sha256 '398a3db6d61899d25fd4a06c6ca12051b0ce171d705decd7ed5511517b4bb93d'
+    end
+
+    resource 'rsa' do
+      url 'https://pypi.python.org/packages/source/r/rsa/rsa-3.1.4.tar.gz'
+      sha256 'e2b0b05936c276b1edd2e1525553233b666df9e29b5c3ba223eed738277c82a0'
+    end
+
+    resource 'sh' do
+      url 'https://pypi.python.org/packages/source/s/sh/sh-1.09.tar.gz'
+      sha256 'f3d174e2ad25c39f28935bae672be51aa083063d3122405ceeb2a3e7a8239d45'
+    end
+
+    resource 'six' do
+      url 'https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz'
+      sha256 'e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5'
+    end
+
+    resource 'websocket-client' do
+      url 'https://pypi.python.org/packages/source/w/websocket-client/websocket_client-0.32.0.tar.gz'
+      sha256 'cb3ab95617ed2098d24723e3ad04ed06c4fde661400b96daa1859af965bfe040'
+    end
+
+    resource 'wheel' do
+      url 'https://pypi.python.org/packages/source/w/wheel/wheel-0.24.0.tar.gz'
+      sha256 'ef832abfedea7ed86b6eae7400128f88053a1da81a37c00613b1279544d585aa'
+    end
+
+    resource 'wsgiref' do
+      url 'https://pypi.python.org/packages/source/w/wsgiref/wsgiref-0.1.2.zip'
+      sha256 'c7e610c800957046c04c8014aab8cce8f0b9f0495c8cd349e57c1f7cabf40e79'
+    end
   end
 
-  resource 'backports.ssl-match-hostname' do
-    url 'https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.4.0.2.tar.gz'
-    sha256 '07410e7fb09aab7bdaf5e618de66c3dac84e2e3d628352814dc4c37de321d6ae'
+  devel do
+    version PebbleSdk::Version.new("4.0-rc0")
+    url 'https://github.com/pebble/pebble-tool.git', :tag => 'v4.0-rc0'
+
+    depends_on 'freetype' => :recommended
+    depends_on 'boost-python'
+
+    depends_on 'pebble-toolchain'
+    depends_on 'pebble-qemu'
+
+    depends_on :python if MacOS.version <= :snow_leopard
+
+    resource 'pypkjs' do
+      url 'https://github.com/pebble/pypkjs.git', :branch => "stable"
+    end
+
+    resource 'backports.ssl-match-hostname' do
+      url 'https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-3.4.0.2.tar.gz'
+      sha256 '07410e7fb09aab7bdaf5e618de66c3dac84e2e3d628352814dc4c37de321d6ae'
+    end
+
+    resource 'colorama' do
+      url 'https://pypi.python.org/packages/source/c/colorama/colorama-0.3.3.tar.gz'
+      sha256 'eb21f2ba718fbf357afdfdf6f641ab393901c7ca8d9f37edd0bee4806ffa269c'
+    end
+
+    resource 'enum34' do
+      url 'https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.tar.gz'
+      sha256 'd3c19f26a6a34629c18c775f59dfc5dd595764c722b57a2da56ebfb69b94e447'
+    end
+
+    resource 'freetype-py' do
+      url 'https://pypi.python.org/packages/source/f/freetype-py/freetype-py-1.0.tar.gz'
+      sha256 '1fc67817d5fb9f1329a1a431850a46f01f250a1d6380e4bcecdb54266023e99a'
+    end
+
+    resource 'gevent' do
+      url 'https://pypi.python.org/packages/source/g/gevent/gevent-1.1b5.tar.gz'
+      sha256 '39e5848b4e8bd20846a43772e1ec8f3c4b8b0cff43611e0d73d809b5dc63f6fb'
+    end
+
+    resource 'gevent-websocket' do
+      url 'https://pypi.python.org/packages/source/g/gevent-websocket/gevent-websocket-0.9.3.tar.gz'
+      sha256 '6475220340f9f8895a0f51bd2b9df3511bc7765dc055f49e997584bdaee3381f'
+    end
+
+    resource 'greenlet' do
+      url 'https://pypi.python.org/packages/source/g/greenlet/greenlet-0.4.7.zip'
+      sha256 'f32c4fa4e06443e1bdb0d32b69e7617c25ff772c3ffc6d0aa63d192e9fd795fe'
+    end
+
+    resource 'httplib2' do
+      url 'https://pypi.python.org/packages/source/h/httplib2/httplib2-0.9.1.tar.gz'
+      sha256 'bc6339919a5235b9d1aaee011ca5464184098f0c47c9098001f91c97176583f5'
+    end
+
+    resource 'libpebble2' do
+      url 'https://pypi.python.org/packages/source/l/libpebble2/libpebble2-0.0.14.tar.gz'
+      sha256 '575bc910dc1c7b7feb70891ef754782fd3c31ebfb0c4b91177bf41cc72b81ece'
+    end
+
+    resource 'oauth2client' do
+      url 'https://pypi.python.org/packages/source/o/oauth2client/oauth2client-1.4.12.tar.gz'
+      sha256 '74aa6c3beb90a4a7b9b8d0bc3cd60db34d45c5ee6136187bb9eabe85b4990e5e'
+    end
+
+    resource 'peewee' do
+      url 'https://pypi.python.org/packages/source/p/peewee/peewee-2.4.7.tar.gz'
+      sha256 '8ad1c4fb202332a969da83a0af712bca96ed6e2a70ca1523ab3d2a2234ed47bd'
+    end
+
+    resource 'progressbar2' do
+      url 'https://pypi.python.org/packages/source/p/progressbar2/progressbar2-2.7.3.tar.gz'
+      sha256 '8366ffc752ebe3c8e50db2699b7b1dc3cb6ff3750065e965a2591ac50270b794'
+    end
+
+    resource 'pyasn1' do
+      url 'https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.1.8.tar.gz'
+      sha256 '5d33be7ca0ec5997d76d29ea4c33b65c00c0231407fff975199d7f40530b8347'
+    end
+
+    resource 'pyasn1-modules' do
+      url 'https://pypi.python.org/packages/source/p/pyasn1-modules/pyasn1-modules-0.0.6.tar.gz'
+      sha256 '1f41d3f3da43e9a769e23649724368aa0b88afcfd1fe6e9f210d31d13322fc15'
+    end
+
+    resource 'pygeoip' do
+      url 'https://pypi.python.org/packages/source/p/pygeoip/pygeoip-0.3.2.tar.gz'
+      sha256 'f22c4e00ddf1213e0fae36dc60b46ee7c25a6339941ec1a975539014c1f9a96d'
+    end
+
+    resource 'pypng' do
+      url 'https://pypi.python.org/packages/source/p/pypng/pypng-0.0.17.tar.gz'
+      sha256 '2dfa74ac28a4c41ae61e62d243410548c7c174bd990528d30270324f15211544'
+    end
+
+    resource 'pyqrcode' do
+      url 'https://pypi.python.org/packages/source/P/PyQRCode/PyQRCode-1.1.tar.gz'
+      sha256 'a22814bf88c8632ebe496e3300793c12471bb448d3186032445990c44ddcdd51'
+    end
+
+    resource 'pyserial' do
+      url 'https://pypi.python.org/packages/source/p/pyserial/pyserial-2.7.tar.gz'
+      sha256 '3542ec0838793e61d6224e27ff05e8ce4ba5a5c5cc4ec5c6a3e8d49247985477'
+    end
+
+    resource 'python-dateutil' do
+      url 'https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.4.1.post1.tar.gz'
+      sha256 'aa9bdbd60c395db90204609f1fb5aeb3797870f65c09f04f243476d22f8f4615'
+    end
+
+    resource 'requests' do
+      url 'https://pypi.python.org/packages/source/r/requests/requests-2.7.0.tar.gz'
+      sha256 '398a3db6d61899d25fd4a06c6ca12051b0ce171d705decd7ed5511517b4bb93d'
+    end
+
+    resource 'rsa' do
+      url 'https://pypi.python.org/packages/source/r/rsa/rsa-3.1.4.tar.gz'
+      sha256 'e2b0b05936c276b1edd2e1525553233b666df9e29b5c3ba223eed738277c82a0'
+    end
+
+    resource 'sh' do
+      url 'https://pypi.python.org/packages/source/s/sh/sh-1.09.tar.gz'
+      sha256 'f3d174e2ad25c39f28935bae672be51aa083063d3122405ceeb2a3e7a8239d45'
+    end
+
+    resource 'six' do
+      url 'https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz'
+      sha256 'e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5'
+    end
+
+    resource 'websocket-client' do
+      url 'https://pypi.python.org/packages/source/w/websocket-client/websocket_client-0.32.0.tar.gz'
+      sha256 'cb3ab95617ed2098d24723e3ad04ed06c4fde661400b96daa1859af965bfe040'
+    end
+
+    resource 'wheel' do
+      url 'https://pypi.python.org/packages/source/w/wheel/wheel-0.24.0.tar.gz'
+      sha256 'ef832abfedea7ed86b6eae7400128f88053a1da81a37c00613b1279544d585aa'
+    end
+
+    resource 'wsgiref' do
+      url 'https://pypi.python.org/packages/source/w/wsgiref/wsgiref-0.1.2.zip'
+      sha256 'c7e610c800957046c04c8014aab8cce8f0b9f0495c8cd349e57c1f7cabf40e79'
+    end
+
+    resource 'netaddr' do
+      url 'https://pypi.python.org/packages/source/n/netaddr/netaddr-0.7.18.zip'
+      sha256 'c64c570ac612e20e8b8a6eee72034c924fff9d76c7a46f50a9f919085f1bfbed'
+    end
   end
 
-  resource 'colorama' do
-    url 'https://pypi.python.org/packages/source/c/colorama/colorama-0.3.3.tar.gz'
-    sha256 'eb21f2ba718fbf357afdfdf6f641ab393901c7ca8d9f37edd0bee4806ffa269c'
+  def cancel_install
+    Curses.close_screen
+    puts "To use the Pebble SDK, you must agree to the Pebble Terms of Use and Pebble Developer License."
+    puts "Cancelling installation of Pebble SDK..."
   end
 
-  resource 'enum34' do
-    url 'https://pypi.python.org/packages/source/e/enum34/enum34-1.0.4.tar.gz'
-    sha256 'd3c19f26a6a34629c18c775f59dfc5dd595764c722b57a2da56ebfb69b94e447'
-  end
+  def check_license_agreement
+    require 'curses'
+    Curses.noecho
+    Curses.init_screen    
+    
+    Curses.addstr("To use the Pebble SDK, you must agree to the following:\n\nPEBBLE TERMS OF USE\nhttps://developer.getpebble.com/legal/terms-of-use\n\nPEBBLE DEVELOPER LICENSE\nhttps://developer.getpebble.com/legal/sdk-license\n\nDo you accept the Pebble Terms of Use and the Pebble Developer License (y/n)? ")
 
-  resource 'freetype-py' do
-    url 'https://pypi.python.org/packages/source/f/freetype-py/freetype-py-1.0.tar.gz'
-    sha256 '1fc67817d5fb9f1329a1a431850a46f01f250a1d6380e4bcecdb54266023e99a'
-  end
+    loop do
+      case Curses.getch
+        when 'y'
+          break
+        when 'n'
+          cancel_install
+          exit
+      end
+    end
 
-  resource 'gevent' do
-    url 'https://pypi.python.org/packages/source/g/gevent/gevent-1.1b5.tar.gz'
-    sha256 '39e5848b4e8bd20846a43772e1ec8f3c4b8b0cff43611e0d73d809b5dc63f6fb'
-  end
-
-  resource 'gevent-websocket' do
-    url 'https://pypi.python.org/packages/source/g/gevent-websocket/gevent-websocket-0.9.3.tar.gz'
-    sha256 '6475220340f9f8895a0f51bd2b9df3511bc7765dc055f49e997584bdaee3381f'
-  end
-
-  resource 'greenlet' do
-    url 'https://pypi.python.org/packages/source/g/greenlet/greenlet-0.4.7.zip'
-    sha256 'f32c4fa4e06443e1bdb0d32b69e7617c25ff772c3ffc6d0aa63d192e9fd795fe'
-  end
-
-  resource 'httplib2' do
-    url 'https://pypi.python.org/packages/source/h/httplib2/httplib2-0.9.1.tar.gz'
-    sha256 'bc6339919a5235b9d1aaee011ca5464184098f0c47c9098001f91c97176583f5'
-  end
-
-  resource 'libpebble2' do
-    url 'https://pypi.python.org/packages/source/l/libpebble2/libpebble2-0.0.14.tar.gz'
-    sha256 '575bc910dc1c7b7feb70891ef754782fd3c31ebfb0c4b91177bf41cc72b81ece'
-  end
-
-  resource 'oauth2client' do
-    url 'https://pypi.python.org/packages/source/o/oauth2client/oauth2client-1.4.12.tar.gz'
-    sha256 '74aa6c3beb90a4a7b9b8d0bc3cd60db34d45c5ee6136187bb9eabe85b4990e5e'
-  end
-
-  resource 'peewee' do
-    url 'https://pypi.python.org/packages/source/p/peewee/peewee-2.4.7.tar.gz'
-    sha256 '8ad1c4fb202332a969da83a0af712bca96ed6e2a70ca1523ab3d2a2234ed47bd'
-  end
-
-  resource 'progressbar2' do
-    url 'https://pypi.python.org/packages/source/p/progressbar2/progressbar2-2.7.3.tar.gz'
-    sha256 '8366ffc752ebe3c8e50db2699b7b1dc3cb6ff3750065e965a2591ac50270b794'
-  end
-
-  resource 'pyasn1' do
-    url 'https://pypi.python.org/packages/source/p/pyasn1/pyasn1-0.1.8.tar.gz'
-    sha256 '5d33be7ca0ec5997d76d29ea4c33b65c00c0231407fff975199d7f40530b8347'
-  end
-
-  resource 'pyasn1-modules' do
-    url 'https://pypi.python.org/packages/source/p/pyasn1-modules/pyasn1-modules-0.0.6.tar.gz'
-    sha256 '1f41d3f3da43e9a769e23649724368aa0b88afcfd1fe6e9f210d31d13322fc15'
-  end
-
-  resource 'pygeoip' do
-    url 'https://pypi.python.org/packages/source/p/pygeoip/pygeoip-0.3.2.tar.gz'
-    sha256 'f22c4e00ddf1213e0fae36dc60b46ee7c25a6339941ec1a975539014c1f9a96d'
-  end
-
-  resource 'pypng' do
-    url 'https://pypi.python.org/packages/source/p/pypng/pypng-0.0.17.tar.gz'
-    sha256 '2dfa74ac28a4c41ae61e62d243410548c7c174bd990528d30270324f15211544'
-  end
-
-  resource 'pyqrcode' do
-    url 'https://pypi.python.org/packages/source/P/PyQRCode/PyQRCode-1.1.tar.gz'
-    sha256 'a22814bf88c8632ebe496e3300793c12471bb448d3186032445990c44ddcdd51'
-  end
-
-  resource 'pyserial' do
-    url 'https://pypi.python.org/packages/source/p/pyserial/pyserial-2.7.tar.gz'
-    sha256 '3542ec0838793e61d6224e27ff05e8ce4ba5a5c5cc4ec5c6a3e8d49247985477'
-  end
-
-  resource 'python-dateutil' do
-    url 'https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.4.1.post1.tar.gz'
-    sha256 'aa9bdbd60c395db90204609f1fb5aeb3797870f65c09f04f243476d22f8f4615'
-  end
-
-  resource 'requests' do
-    url 'https://pypi.python.org/packages/source/r/requests/requests-2.7.0.tar.gz'
-    sha256 '398a3db6d61899d25fd4a06c6ca12051b0ce171d705decd7ed5511517b4bb93d'
-  end
-
-  resource 'rsa' do
-    url 'https://pypi.python.org/packages/source/r/rsa/rsa-3.1.4.tar.gz'
-    sha256 'e2b0b05936c276b1edd2e1525553233b666df9e29b5c3ba223eed738277c82a0'
-  end
-
-  resource 'sh' do
-    url 'https://pypi.python.org/packages/source/s/sh/sh-1.09.tar.gz'
-    sha256 'f3d174e2ad25c39f28935bae672be51aa083063d3122405ceeb2a3e7a8239d45'
-  end
-
-  resource 'six' do
-    url 'https://pypi.python.org/packages/source/s/six/six-1.9.0.tar.gz'
-    sha256 'e24052411fc4fbd1f672635537c3fc2330d9481b18c0317695b46259512c91d5'
-  end
-
-  resource 'websocket-client' do
-    url 'https://pypi.python.org/packages/source/w/websocket-client/websocket_client-0.32.0.tar.gz'
-    sha256 'cb3ab95617ed2098d24723e3ad04ed06c4fde661400b96daa1859af965bfe040'
-  end
-
-  resource 'wheel' do
-    url 'https://pypi.python.org/packages/source/w/wheel/wheel-0.24.0.tar.gz'
-    sha256 'ef832abfedea7ed86b6eae7400128f88053a1da81a37c00613b1279544d585aa'
-  end
-
-  resource 'wsgiref' do
-    url 'https://pypi.python.org/packages/source/w/wsgiref/wsgiref-0.1.2.zip'
-    sha256 'c7e610c800957046c04c8014aab8cce8f0b9f0495c8cd349e57c1f7cabf40e79'
-  end
-
-  resource 'netaddr' do
-    url 'https://pypi.python.org/packages/source/n/netaddr/netaddr-0.7.18.zip'
-    sha256 'c64c570ac612e20e8b8a6eee72034c924fff9d76c7a46f50a9f919085f1bfbed'
+    Curses.close_screen
   end
 
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+    if build.stable?
+      check_license_agreement
+      inreplace 'bin/pebble' do |s|
+        # This replacement fixes a path that gets messed up because of the
+        # bin.env_script_all_files call (which relocates actual pebble.py script
+        # to libexec/, causing problems with the absolute path expected below).
+        s.gsub! /^script_path = .*?$/m, "script_path = '#{libexec}/../pebble-tool/pebble.py'"
 
-    resource('pypkjs').stage { (libexec/"pypkjs").install Dir["*"] }
+        # This replacement removes environment settings that were needed only
+        # if installation was done with the official script
+        s.gsub! /^local_python_env.*?=.*?\(.*?\)$/m, ""
+        s.gsub! /^process = subprocess\.Popen\(args, shell=False, env=local_python_env\)/, "process = subprocess.Popen(args, shell=False)"
+      end
 
-    %w[backports.ssl-match-hostname colorama enum34 freetype-py gevent gevent-websocket greenlet httplib2 libpebble2 pyasn1 pyasn1-modules oauth2client peewee progressbar2 pygeoip pypng pyqrcode pyserial python-dateutil requests rsa sh six websocket-client wheel wsgiref netaddr].each do |r|
-      resource(r).stage { system "python", *Language::Python.setup_install_args(libexec/"vendor") }
+      ENV["PYTHONPATH"] = lib+"python2.7/site-packages"
+      ENV.prepend_create_path 'PYTHONPATH', libexec+'lib/python2.7/site-packages'
+      ENV.prepend_create_path "PATH", libexec/"bin"
+      install_args = [ "setup.py", "install", "--prefix=#{libexec}" ]
+
+      %w[backports.ssl-match-hostname colorama enum34 freetype-py gevent gevent-websocket greenlet httplib2 libpebble2 pyasn1 pyasn1-modules oauth2client peewee progressbar2 pygeoip pypng pyqrcode pyserial python-dateutil requests rsa sh six websocket-client wheel wsgiref].each do |r|
+        resource(r).stage { system "python", *install_args }
+      end
+  
+      doc.install %w[Documentation Examples README.txt]
+      prefix.install %w[Pebble bin pebble-tool requirements.txt version.txt]
+
+      ln_s "#{HOMEBREW_PREFIX}/Cellar/pebble-toolchain/2.0/arm-cs-tools", "#{prefix}"
+
+      bin.env_script_all_files(libexec+'bin', :PYTHONPATH => ENV['PYTHONPATH'])
+    elsif build.devel?
+      ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
+      ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+
+      resource('pypkjs').stage { (libexec/"pypkjs").install Dir["*"] }
+
+      %w[backports.ssl-match-hostname colorama enum34 freetype-py gevent gevent-websocket greenlet httplib2 libpebble2 pyasn1 pyasn1-modules oauth2client peewee progressbar2 pygeoip pypng pyqrcode pyserial python-dateutil requests rsa sh six websocket-client wheel wsgiref netaddr].each do |r|
+        resource(r).stage { system "python", *Language::Python.setup_install_args(libexec/"vendor") }
+      end
+
+      system "python", *Language::Python.setup_install_args(libexec)
+
+      bin.install Dir[libexec/"bin/*"]
+      bin.env_script_all_files(
+        libexec/"bin",
+        :PYTHONPATH => ENV["PYTHONPATH"],
+        :PHONESIM_PATH => libexec/"pypkjs/phonesim.py",
+        :PEBBLE_TOOLCHAIN_PATH => HOMEBREW_PREFIX/"Cellar/pebble-toolchain/2.0/arm-cs-tools/bin",
+      )
     end
-
-    system "python", *Language::Python.setup_install_args(libexec)
-
-    bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(
-      libexec/"bin",
-      :PYTHONPATH => ENV["PYTHONPATH"],
-      :PHONESIM_PATH => libexec/"pypkjs/phonesim.py",
-      :PEBBLE_TOOLCHAIN_PATH => HOMEBREW_PREFIX/"Cellar/pebble-toolchain/2.0/arm-cs-tools/bin",
-    )
   end
 
   test do

--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -1,8 +1,8 @@
 class PebbleSdk < Formula
   class Version < ::Version
     def <=> (other)
-      mine = ::Version.new(self.to_s.sub('dp', 'alpha'))
-      other = ::Version.new(other.to_s.sub('dp', 'alpha'))
+      mine = ::Version.new(self.to_s.sub('dp', 'alpha').to_s.sub('rc', 'beta'))
+      other = ::Version.new(other.to_s.sub('dp', 'alpha').to_s.sub('rc', 'beta'))
       mine <=> other
     end
   end


### PR DESCRIPTION
This PR brings us (partially) into our new world!

It adds a new 'devel' variant to pebble-sdk, which installs our new-style tool, version 4.0-rc0 (directly from git, at the moment). This is activated by passing `--devel` to homebrew, like `brew install --devel pebble-sdk`. The old thing is installed if this is omitted.

It also adds a `pebble-qemu` formula that installs a `qemu-pebble` binary, which is a dependency of the new `pebble-sdk`.

`-beta` and `-legacy` are left alone for now, but will be obsolete soon.