### PR TITLE
EOS undent fix

### DIFF
--- a/pebble-sdk.rb
+++ b/pebble-sdk.rb
@@ -219,7 +219,7 @@ class PebbleSdk < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS.undent
       
       Documentation can be found online at https://developer.pebble.com/docs
 


### PR DESCRIPTION
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/pebble/homebrew-pebble-sdk/pebble-sdk.rb:228:in `caveats'
Please report this to the pebble/pebble-sdk tap!
Or, even better, submit a PR to fix it!

MacOS version: 10.12.5
Homebrew version: 1.6.8